### PR TITLE
Adding PHPUnit test support and tests for AlertItem::crop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ examples/*.prod.php
 examples/*.pem
 vendor/
 composer.lock
+composer.phar
+phpunit.xml
+bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "autoload": {
         "psr-4": {"alxmsl\\APNS\\": "source/"}
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.6.*"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="true">
+    <testsuites>
+        <testsuite name="APNSClient">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/Notification/AlertItemTest.php
+++ b/test/Notification/AlertItemTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace alxmsl\APNS\Test\Notification;
+
+use alxmsl\APNS\Notification\AlertItem;
+use alxmsl\APNS\Notification\Exception\CannotCropBodyException;
+
+/**
+ * Test AlertItem behavior
+ * @author Andrey Artemov <andrey.artemov@gmail.com>
+ */
+class AlertItemTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Checking correct body crop in AlertItem::crop()
+     * @dataProvider getBodiesForCrop
+     *
+     * @param string $body
+     * @param int $cropLength
+     * @param string $expectedBody
+     */
+    public function testCrop($body, $cropLength, $expectedBody) {
+        // checking correct internal encoding
+        $this->assertSame('UTF-8', mb_internal_encoding());
+
+        $Item = new AlertItem();
+        $Item->setBody($body);
+        $Item->crop($cropLength);
+        $this->assertSame($expectedBody, $Item->getBody());
+    }
+
+    /**
+     * Getting different test cases for checking correct body crop in AlertItem::crop()
+     * @return array
+     */
+    public function getBodiesForCrop() {
+        return [
+            // body length is shorter than crop length
+            [str_repeat('а', 9),  10, str_repeat('а', 9)],
+            // body length is equal to crop length
+            [str_repeat('а', 10), 10, str_repeat('а', 10)],
+            // body length is greater than crop length
+            [str_repeat('а', 11), 10, str_repeat('а', 9) . AlertItem::POSTFIX],
+        ];
+    }
+
+    /**
+     * Checking expected exception is thrown when cropping length is less then minimum body length
+     */
+    public function testExceptionIsThrownWhenCropLengthIsLessThenMinimumLength() {
+        $minimumLength = 5;
+        $Item = new AlertItem($minimumLength);
+        $Item->setBody('foobar');
+
+        $this->setExpectedException(CannotCropBodyException::class);
+        $Item->crop($minimumLength - 1);
+    }
+
+    /**
+     * Checking expected exception is thrown when cropping length is equal to minimum body length
+     */
+    public function testExceptionIsThrownWhenCropLengthIsEqualToMinimumLength() {
+        $minimumLength = 5;
+        $Item = new AlertItem($minimumLength);
+        $Item->setBody('foobar');
+
+        $this->setExpectedException(CannotCropBodyException::class);
+        $Item->crop($minimumLength);
+    }
+
+}


### PR DESCRIPTION
I've found that `AlertItem::crop()` is working not correct (see PHPUnit results below):

```
$ ./vendor/bin/phpunit
PHPUnit 4.6.10 by Sebastian Bergmann and contributors.

Configuration read from /Users/andrey/Work/dec5e/APNSClient/phpunit.xml

FFF..

Time: 163 ms, Memory: 4.25Mb

There were 3 failures:

1) alxmsl\APNS\Test\Notification\AlertItemTest::testCrop with data set #0 ('ааааааааа', 10, 'ааааааааа')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-ааааааааа
+ааа…

/Users/andrey/Work/dec5e/APNSClient/test/Notification/AlertItemTest.php:29

2) alxmsl\APNS\Test\Notification\AlertItemTest::testCrop with data set #1 ('аааааааааа', 10, 'аааааааааа')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-аааааааааа
+ааа…

/Users/andrey/Work/dec5e/APNSClient/test/Notification/AlertItemTest.php:29

3) alxmsl\APNS\Test\Notification\AlertItemTest::testCrop with data set #2 ('ааааааааааа', 10, 'ааааааааа…')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-ааааааааа…
+ааа…

/Users/andrey/Work/dec5e/APNSClient/test/Notification/AlertItemTest.php:29

FAILURES!
Tests: 5, Assertions: 8, Failures: 3.
```

BTW, I'm not sure that behavior seen in `AlertItemTest::testExceptionIsThrownWhenCropLengthIsEqualToMinimumLength()` is correct. Is it right that exception is thrown when crop length is equal to minimum length?
