### PR TITLE
Fixing AlertItem::crop() behavior

### DIFF
--- a/source/Notification/AlertItem.php
+++ b/source/Notification/AlertItem.php
@@ -275,7 +275,9 @@ final class AlertItem implements JsonSerializable {
      */
     public function crop($length) {
         if ($length > $this->minimumLength) {
-            $this->body = mb_strcut($this->body, 0, $length - strlen(self::POSTFIX)) . self::POSTFIX;
+            if (mb_strlen($this->body) > $length) {
+                $this->body = mb_substr($this->body, 0, $length - mb_strlen(self::POSTFIX)) . self::POSTFIX;
+            }
         } else {
             throw new CannotCropBodyException();
         }


### PR DESCRIPTION
From PHP manual: "`mb_strcut()` extracts a substring from a string similarly to `mb_substr()`, but operates on bytes instead of characters.". 

Also I disable crop when body length is shorter than crop length.

Fixed tests from #1:

```
$ ./vendor/bin/phpunit
PHPUnit 4.6.10 by Sebastian Bergmann and contributors.

Configuration read from /Users/andrey/Work/dec5e/APNSClient/phpunit.xml

.....

Time: 150 ms, Memory: 4.00Mb

OK (5 tests, 8 assertions)
```
