### PR TITLE
Adding PHPUnit test support and tests for AlertItem::crop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ examples/*.prod.php
 examples/*.pem
 vendor/
 composer.lock
+composer.phar
+phpunit.xml
+bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "autoload": {
         "psr-4": {"alxmsl\\APNS\\": "source/"}
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.6.*"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="APNSClient">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/Notification/AlertItemTest.php
+++ b/test/Notification/AlertItemTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace alxmsl\APNS\Test\Notification;
+
+use alxmsl\APNS\Notification\AlertItem;
+use alxmsl\APNS\Notification\Exception\CannotCropBodyException;
+
+/**
+ * Test AlertItem behavior
+ * @author Andrey Artemov <andrey.artemov@gmail.com>
+ */
+class AlertItemTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Checking correct body crop in AlertItem::crop()
+     * @dataProvider getBodiesForCrop
+     *
+     * @param string $body
+     * @param int $cropLength
+     * @param string $expectedBody
+     */
+    public function testCrop($body, $cropLength, $expectedBody) {
+        // checking correct internal encoding
+        $this->assertSame('UTF-8', mb_internal_encoding());
+
+        $Item = new AlertItem();
+        $Item->setBody($body);
+        $Item->crop($cropLength);
+        $this->assertSame($expectedBody, $Item->getBody());
+    }
+
+    /**
+     * Getting different test cases for checking correct body crop in AlertItem::crop()
+     * @return array
+     */
+    public function getBodiesForCrop() {
+        return [
+            ['абв', 7, 'аб…'], // 7 bytes
+            ['абв', 6, 'а…'],  // 5 bytes
+            ['абв', 5, 'а…'],  // 5 bytes
+            ['абв', 4, '…'],   // 3 bytes
+        ];
+    }
+
+    /**
+     * Checking expected exception is thrown when cropping length is less then minimum body length
+     */
+    public function testExceptionIsThrownWhenCropLengthIsLessThenMinimumLength() {
+        $minimumLength = 5;
+        $Item = new AlertItem($minimumLength);
+        $Item->setBody('foobar');
+
+        $this->setExpectedException(CannotCropBodyException::class);
+        $Item->crop($minimumLength - 1);
+    }
+
+    /**
+     * Checking expected exception is thrown when cropping length is equal to minimum body length
+     */
+    public function testExceptionIsThrownWhenCropLengthIsEqualToMinimumLength() {
+        $minimumLength = 5;
+        $Item = new AlertItem($minimumLength);
+        $Item->setBody('foobar');
+
+        $this->setExpectedException(CannotCropBodyException::class);
+        $Item->crop($minimumLength);
+    }
+
+}


### PR DESCRIPTION
I've changed tests from #1 with correct behavior and now all tests are passing:

```
$ ./vendor/bin/phpunit
PHPUnit 4.6.10 by Sebastian Bergmann and contributors.

Configuration read from /Users/andrey/Work/dec5e/APNSClient/phpunit.xml

......

Time: 160 ms, Memory: 4.00Mb

OK (6 tests, 10 assertions)
```
